### PR TITLE
Release 0.1.3: drag/drop images + copy/paste move

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ A local-first markdown note-taking desktop app. Your notes are stored as plain `
 
 | Platform | Download |
 |----------|----------|
-| **macOS (Apple Silicon)** | [Brain Pad_0.1.2_aarch64.dmg](https://github.com/dennisivy/BrainPad/releases/download/v0.1.2/Brain%20Pad_0.1.2_aarch64.dmg) |
-| **macOS (Intel)** | [Brain Pad_0.1.2_x64.dmg](https://github.com/dennisivy/BrainPad/releases/download/v0.1.2/Brain%20Pad_0.1.2_x64.dmg) |
+| **macOS (Apple Silicon)** | [Brain Pad_0.1.3_aarch64.dmg](https://github.com/dennisivy/BrainPad/releases/download/v0.1.3/Brain%20Pad_0.1.3_aarch64.dmg) |
+| **macOS (Intel)** | [Brain Pad_0.1.3_x64.dmg](https://github.com/dennisivy/BrainPad/releases/download/v0.1.3/Brain%20Pad_0.1.3_x64.dmg) |
 | **Windows** | Coming soon |
 | **Linux** | Coming soon |
 
@@ -94,9 +94,10 @@ Or browse all releases: [Releases Page](https://github.com/dennisivy/BrainPad/re
    ```
 
 5. Find your built app:
-- **macOS**: `src-tauri/target/release/bundle/dmg/Brain Pad_0.1.2_aarch64.dmg`
-   - **Windows**: `src-tauri/target/release/bundle/msi/`
-   - **Linux**: `src-tauri/target/release/bundle/appimage/` or `deb/`
+- **macOS (Apple Silicon)**: `src-tauri/target/release/bundle/dmg/Brain Pad_0.1.3_aarch64.dmg`
+- **macOS (Intel)**: `src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Brain Pad_0.1.3_x64.dmg`
+- **Windows**: `src-tauri/target/release/bundle/msi/`
+- **Linux**: `src-tauri/target/release/bundle/appimage/` or `deb/`
 
 ## Usage
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'src-tauri/target']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brain-pad",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brain-pad",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@milkdown/core": "^7.18.0",
         "@milkdown/ctx": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brain-pad",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,100 @@
+# Image click-to-reveal markdown + paste-to-image (cleanup drag/drop code)
+
+## Problem statement
+Users want to click an image in the editor to reveal its markdown syntax (for copy/paste), and when that markdown is pasted back into the editor it should render as an image. We also want to remove leftover/abandoned drag/drop “reordering” experiments so we don’t keep dead code.
+
+## Current state
+- Dragging an image file into an open note copies it into `<notesDirectory>/media/` and inserts an image node.
+- Local images are rendered via `readFile(...) -> Blob -> URL.createObjectURL(...)` in the image node view.
+- Drag/drop reordering attempts introduced custom drag/drop code inside `src/components/MilkdownEditor.tsx`.
+
+## Decisions (confirmed)
+- The revealed markdown should match what the file contains (plain markdown image syntax).
+- Copy should be easy (auto-select and/or copy button).
+- Pasting that syntax back should render as an image.
+
+## Proposed changes
+
+### 1) Cleanup drag/drop reordering code
+In `src/components/MilkdownEditor.tsx`:
+- Remove custom internal drag/drop handling for reordering.
+- Keep only OS-file-drop prevention (so the webview doesn’t try to open dropped files) and the existing Tauri `onDragDropEvent` import flow.
+
+### 2) Click image to reveal markdown syntax
+Extend the existing image node view so clicking an image:
+- Opens a small popover near the image (similar to the existing code-block language picker UI).
+- Shows the exact markdown string: `![alt](src)` or `![alt](src "title")`.
+- Auto-selects the text and provides a “Copy” button.
+- Dismisses on Escape or click outside.
+
+### 3) Paste handler: markdown image syntax -> image node(s)
+Add a ProseMirror plugin (in `MilkdownEditor.tsx`) with `handlePaste` that:
+- Reads pasted plain text.
+- Detects one or multiple markdown image patterns.
+- Replaces the selection with image node(s) (and optional trailing space/paragraph) rather than plain text.
+
+This ensures copy/paste works even though input rules do not reliably run on paste.
+
+### 4) Styling
+Add minimal styles in `src/index.css` for the popover (dark theme, small input, copy button).
+
+## Verification
+- Drag-drop an image file into a note (existing behavior should still work).
+- Click the rendered image → popover shows markdown and copies.
+- Paste the copied markdown back into the editor → it renders as an image.
+- Confirm no extra drag/drop reordering code remains.
+
+---
+
+# Copy→Paste to reposition image (auto-delete original)
+
+## Problem statement
+When repositioning an image inside a note, users currently have to copy/paste the image markdown and then manually delete the original image. We want a smoother flow: click **Copy** on an image → show a toast “Image copied, paste to reposition” → when the user pastes, the image is inserted at the cursor and the original image node is deleted automatically.
+
+## Current state
+- Images are inserted as Milkdown/ProseMirror `image` nodes and stored as markdown `![alt](src "title")`.
+- There is already an image click popover with a **Copy** button and a paste handler that converts pasted markdown image syntax into image nodes.
+
+## Proposed changes
+
+### 1) Track a “pending move” after Copy
+When the user clicks **Copy** on an image:
+- Write the image markdown to clipboard (current behavior).
+- Record a `pendingMove` object in the editor plugin state:
+  - `noteKey` (the active note path) so we only auto-delete when pasting into the same note.
+  - `pos` (the image node position via `getPos()` from the node view).
+  - `attrs` (`src`, `alt`, `title`) and `markdown`.
+- Show a non-blocking toast: “Image copied — paste to reposition (Esc to cancel)”.
+- If the user copies another image, overwrite `pendingMove`.
+- Allow cancel by pressing Escape (clears `pendingMove`).
+
+### 2) On paste, “move” instead of “duplicate” when it matches pendingMove
+In the existing `handlePaste`:
+- Parse pasted plain text. If it’s exactly one image markdown and matches `pendingMove.markdown` (or matching attrs), and `noteKey` matches:
+  - Compute insertion position from the current selection.
+  - Delete the original image node at `pendingMove.pos` (only if it still exists and matches attrs; otherwise clear pendingMove and fall back to normal paste behavior).
+  - Insert the image node at the cursor.
+  - Clear `pendingMove`.
+  - Show toast: “Image moved”.
+- If paste doesn’t match `pendingMove`, behave as today (convert markdown → image node(s), no deletion).
+
+### 3) Keep OS file drop behavior intact
+Continue preventing ProseMirror from handling OS file drops (to avoid the webview trying to open dropped files). Tauri `onDragDropEvent` continues to import images into `media/`.
+
+### 4) Implementation notes
+- Update the image node view signature to `image(node, view, getPos)` so we can store the correct node position on Copy.
+- Store `pendingMove` in plugin state and map `pos` through transactions using `tr.mapping` so it remains valid across edits.
+- If `pendingMove.pos` becomes invalid (node deleted/changed), automatically clear `pendingMove`.
+
+## UX
+- Toast appears after Copy.
+- Escape cancels the pending move.
+- Pasting anywhere in the same note performs the move.
+- Pasting into another note will not delete the original.
+
+## Verification
+- Drag-drop an image into a note (still works).
+- Click image → Copy → toast appears.
+- Paste elsewhere in the same note → image appears at cursor and original disappears.
+- Paste into a different note → image is inserted, original remains.
+- Copy an image, then delete it, then paste → paste inserts image but no deletion occurs (and pendingMove clears).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "brain-pad"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brain-pad"
-version = "0.1.2"
+version = "0.1.3"
 description = "A local-first markdown note-taking app"
 authors = ["Dennis Ivy"]
 license = "MIT"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,8 @@
     "fs:allow-read-dir",
     "fs:allow-read-file",
     "fs:allow-exists",
+    "fs:allow-copy-file",
+    "fs:allow-mkdir",
     "fs:allow-home-write-recursive",
     "fs:allow-home-read-recursive",
     "fs:allow-desktop-write-recursive",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Brain Pad",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.brainpad.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,6 +161,7 @@ function App() {
         onChange={updateNoteContent}
         disabled={!activeNote}
         notesDirectory={notesDirectory}
+        notePath={activeNote?.path ?? null}
       />
       {isSaving && <div className="save-indicator">Saving...</div>}
       {error && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,6 +160,7 @@ function App() {
         content={activeNote?.content ?? ''}
         onChange={updateNoteContent}
         disabled={!activeNote}
+        notesDirectory={notesDirectory}
       />
       {isSaving && <div className="save-indicator">Saving...</div>}
       {error && (

--- a/src/components/NewNoteModal.tsx
+++ b/src/components/NewNoteModal.tsx
@@ -11,10 +11,13 @@ export function NewNoteModal({ isOpen, onClose, onSubmit }: NewNoteModalProps) {
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if (isOpen) {
+    if (!isOpen) return
+
+    // Defer state updates to avoid synchronous setState-in-effect warnings.
+    setTimeout(() => {
       setFilename('')
-      setTimeout(() => inputRef.current?.focus(), 0)
-    }
+      inputRef.current?.focus()
+    }, 0)
   }, [isOpen])
 
   function handleSubmit(e: React.FormEvent) {

--- a/src/components/RenameNoteModal.tsx
+++ b/src/components/RenameNoteModal.tsx
@@ -12,14 +12,15 @@ export function RenameNoteModal({ isOpen, currentName, onClose, onSubmit }: Rena
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    if (isOpen) {
+    if (!isOpen) return
+
+    // Defer state updates to avoid synchronous setState-in-effect warnings.
+    setTimeout(() => {
       // Remove .md extension for editing
       setFilename(currentName.replace('.md', ''))
-      setTimeout(() => {
-        inputRef.current?.focus()
-        inputRef.current?.select()
-      }, 0)
-    }
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }, 0)
   }, [isOpen, currentName])
 
   function handleSubmit(e: React.FormEvent) {

--- a/src/index.css
+++ b/src/index.css
@@ -141,6 +141,55 @@ button:disabled {
   padding: 4px;
 }
 
+/* Image markdown popover (click image to copy markdown) */
+.image-markdown-popover {
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  min-width: 320px;
+  max-width: 520px;
+  background-color: rgba(59, 66, 82, 0.95);
+  border: 1px solid rgba(94, 129, 172, 0.5);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.image-markdown-input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  color: #eceff4;
+  background: rgba(46, 52, 64, 0.85);
+  border: 1px solid rgba(76, 86, 106, 0.8);
+  border-radius: 6px;
+  outline: none;
+}
+
+.image-markdown-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.image-markdown-copy {
+  padding: 8px 10px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(94, 129, 172, 0.7);
+  background: rgba(94, 129, 172, 0.25);
+  color: #eceff4;
+  cursor: pointer;
+}
+
+.image-markdown-copy:hover {
+  background: rgba(94, 129, 172, 0.35);
+}
+
 .language-select {
   background-color: rgba(59, 66, 82, 0.9);
   color: #d8dee9;

--- a/src/index.css
+++ b/src/index.css
@@ -190,6 +190,25 @@ button:disabled {
   background: rgba(94, 129, 172, 0.35);
 }
 
+.image-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 22px;
+  transform: translateX(-50%);
+  z-index: 10001;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(46, 52, 64, 0.92);
+  border: 1px solid rgba(94, 129, 172, 0.55);
+  color: #eceff4;
+  font-size: 13px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+  transition: opacity 200ms ease;
+  pointer-events: none;
+  max-width: min(560px, calc(100vw - 40px));
+  text-align: center;
+}
+
 .language-select {
   background-color: rgba(59, 66, 82, 0.9);
   color: #d8dee9;


### PR DESCRIPTION
Includes:
- Drag-and-drop image import into per-notes `media/` folder + in-editor rendering
- Image click popover to reveal markdown + Copy
- Paste image markdown to render as images
- Copy → Paste to reposition (auto-deletes original within same note)
- Bump version to 0.1.3 + update README download links

Local build artifacts (upload to GitHub Release v0.1.3):
- src-tauri/target/release/bundle/dmg/Brain Pad_0.1.3_aarch64.dmg
- src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/Brain Pad_0.1.3_x64.dmg

Co-Authored-By: Warp <agent@warp.dev>
